### PR TITLE
Reorder widgets

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -31,9 +31,13 @@ header span {
 main {
   break-inside: avoid;
   column-count: 3;
-  column-width: 15em; 
+  column-width: 15em;
   padding: 10px;
   width: 100%;
+}
+
+section {
+  break-inside: avoid;
 }
 
 container {
@@ -77,6 +81,9 @@ p {
   font-size: 16px;
 }
 
+#user-admin-info {
+  display: none;
+}
 #user-admin-info p {
   font-weight: bold;
 }
@@ -131,7 +138,3 @@ img {
   padding-left: 2px;
   padding-right: 2px;
 }
-
-
-
-

--- a/src/index.html
+++ b/src/index.html
@@ -13,8 +13,23 @@
       <h1> Activity Tracker</h1>
       <p>Welcome, <span id="user-name"></span>!</p>
       <p>Today's Date: <span id="current-date"></span></p>
-    </header>
-    <main>
+      <section class="dropdown">
+        <input type="hidden" value="All info">
+        <header><p>All info</p></header>
+        <div>
+          <p>All info</p>
+          <p>Today</p>
+          <p>Week</p>
+          <p>Average</p>
+        </div>
+      </section>
+      <form class="switch">
+        <input name="switch" class="players pl-1" id="light" type="radio" value="light" />
+        <label for="light" class="switch__label">Light</label>
+        <input name="switch" class="players pl-2"  id="dark" type="radio" value="Dark" checked />
+        <label for="dark" class="switch__label">Dark</label>
+        <div class="switch__indicator"></div>
+      </form>
       <container id="user-admin-info">
         <h3>User Info</h3>
         <p class="user-info">Name: <span id="user-info-name"></span></p>
@@ -22,55 +37,85 @@
         <p class="user-info">Address: <span id="user-info-address"></span></p>
         <p class="user-info">Step Goal: <span id="user-info-step-goal"></span></p>
       </container>
-      <container class="container-center">
-        <p>You've consumed</p> 
-        <span id="user-water-by-day"></span> <p> ounces of water today</p>
-      </container>
+    </header>
+    <main>
+      <section>
+        <container class="container-center">
+          <h3>Water</h3>
+          <p>You've consumed</p>
+          <span id="user-water-by-day"></span> <p> ounces of water today</p>
+        </container>
+        <container>
+          <h3>Weekly Water Consumption</h3>
+          <canvas id="user-water-by-week" width="300" height="150"></canvas>
+        </container>
+        <container class="container-center" id="user-water-trend-week">
+          <h3>Have You Had Enough Water Today?</h3>
+          <img id="water-status"></img>
+          <p id="water-comment">Keep up the good work! You've averaged more than 64 ounces per day this week</p>
+        </container>
+        <container class="container-center">
+          <h3>Your Water Average</h3>
+          <p>You've consumed</p>
+          <span id="user-water-by-day">57</span> <p> ounces of water average</p>
+        </container>
+      </section>
+      <section>
+        <container class="container-center" id="user-sleep-day">
+          <h3>Last Night's Sleep</h3>
+          <p class="number"id="user-sleep-by-day"></p>
+          <h4>hours slept</h4>
+          <p class="number" id="user-sleep-quality-by-day"></p>
+          <h4>sleep quality</h4>
+        </container>
+        <container class="container-center" id="user-rested">
+          <h3 >How Rested Are You Today?</h3>
+          <img id="sleep-status"></img>
+          <p id="sleep-comment">Getting 8 hours of sleep will make you more productive!</p>
+        </container>
+        <container id="user-sleep-week">
+          <h3>Your Sleep Quality & Hours</h3>
+          <canvas id="user-sleep-by-week"></canvas>
+        </container>
+        <container class="container-center">
+          <h3>Your Sleep Averages</h3>
+          <p class="number" id="user-average-hours-slept">
+          <h4>hours slept</h4>
+          <p class="number" id="user-average-sleep-quality"></p>
+          <h4>sleep quality</h4>
+          </p>
+        </container>
+      </section>
+      <section>
+        <container class="container-center" id="user-activity-day">
+          <h3>Today's Activity</h3>
+          <p class="number" id="user-current-step-count"></p>
+          <h4>steps</h4>
+          <p class="number" id="user-current-mins-active"></p>
+          <h4>active minutes</h4>
+          <p class="number" id="user-current-miles-walked"></p>
+          <h4>miles</h4>
+        </container>
+        <container id="building-challenge">
+          <h3>Republic Plaza Challenge</h3>
+          <img src='../images/building.svg'>
+          <p>In the last year you have climbed the Republic Plaza Building in Denver, CO <span id="republic-plaza-challenge"></span> times!</p>
+        </container>
+        <container>
+          <h3>Your Step Count This Week</h3>
+          <canvas id="user-step-count-by-week"></canvas>
+          <!-- <h3>Your Active Minutes This Week</h3>
+          <canvas id="user-mins-active-by-week"></canvas>
+          <h3>Your Stairs Climbed This Week</h3>
+          <canvas id="user-stairs-climbed-by-week"></canvas> -->
+        </container>
+      </section>
+    </main>
+    <main>
       <container>
-        <h3>Weekly Water Consumption</h3>
-        <canvas id="user-water-by-week" width="300" height="150"></canvas>
-      </container>
-      <container class="container-center" id="user-sleep-day">
-        <h3>Last Night's Sleep</h3>
-        <p class="number"id="user-sleep-by-day"></p>
-        <h4>hours slept</h4>
-        <p class="number" id="user-sleep-quality-by-day"></p>
-        <h4>sleep quality</h4>
-      </container>
-      <container class="container-center" id="user-rested">
-        <h3 >How Rested Are You Today?</h3>
-        <img id="sleep-status"></img>
-        <p id="sleep-comment">Getting 8 hours of sleep will make you more productive!</p>
-      </container>
-      <container class="container-center" id="user-rested">
-        <h3>Step Trend</h3>
-        <canvas id="step-trend"></canvas>
-      </container>
-      <container id="user-sleep-week">
-        <h3>Your Sleep Quality & Hours</h3>
-        <canvas id="user-sleep-by-week"></canvas>
-      </container>
-      <container class="container-center" id="user-water-trend-week">
-        <h3>Have You Had Enough Water Today?</h3>
-        <img id="water-status"></img>
-        <p id="water-comment">Keep up the good work! You've averaged more than 64 ounces per day this week</p>
-      </container>
-      <container class="container-center">
-        <h3>Your Sleep Averages</h3>
-        <p class="number" id="user-average-hours-slept">
-        <h4>hours slept</h4>
-        <p class="number" id="user-average-sleep-quality"></p>
-        <h4>sleep quality</h4>
-        </p>
-      </container>
-      <container class="container-center" id="user-activity-day">
-        <h3>Today's Activity</h3>
-        <p class="number" id="user-current-step-count"></p>
-        <h4>steps</h4>
-        <p class="number" id="user-current-mins-active"></p>
-        <h4>active minutes</h4>
-        <p class="number" id="user-current-miles-walked"></p>
-        <h4>miles</h4>
+        <h3>Friends: Weekly Step Challenge</h3>
+        <p id="winner-name"></p>
+        <canvas id="friend-info"></canvas>
       </container>
       <container class="you-vs-world">
         <h3>You vs The World</h3>
@@ -84,27 +129,9 @@
         <p>You: <span id="user-current-stairs-climbed"></span></p>
         <p>World Avg: <span id="all-users-average-stairs-climbed"></span></p>
       </container>
-      <container>
-        <h3>Your Step Count This Week</h3>
-        <canvas id="user-step-count-by-week"></canvas>
-      </container>
-      <container>
-        <h3>Your Active Minutes This Week</h3>
-        <canvas id="user-mins-active-by-week"></canvas>
-      </container>
-      <container>
-        <h3>Your Stairs Climbed This Week</h3>
-        <canvas id="user-stairs-climbed-by-week"></canvas>
-      </container>
-      <container id="building-challenge">
-        <h3>Republic Plaza Challenge</h3>
-        <img src='../images/building.svg'>
-        <p>In the last year you have climbed the Republic Plaza Building in Denver, CO <span id="republic-plaza-challenge"></span> times!</p>
-      </container>
-      <container>
-        <h3>Friends: Weekly Step Challenge</h3>
-        <p id="winner-name"></p>
-        <canvas id="friend-info"></canvas>
+      <container class="container-center" id="user-rested">
+        <h3>Step Trend</h3>
+        <canvas id="step-trend"></canvas>
       </container>
     </main>
     <script src="https://code.jquery.com/jquery-3.2.1.min.js"


### PR DESCRIPTION
I made some changes in html structure. I changed order of widgets, so now it has 3 different column with the same topics of widgets. I added html structure of light/dark mode switcher and filter button, But don't apply any styles for it  Also I deleted info block from main page. I will replace to header and it will be hidden while user don't click on  user icon / name.  
@JamesRexMiller4 @Garrett-Iannuzzi 

<img width="645" alt="Screen Shot 2019-10-18 at 6 54 22 PM" src="https://user-images.githubusercontent.com/48605821/67136119-30308d00-f1df-11e9-9615-7988dd947ceb.png">
